### PR TITLE
Feature/file drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ redBorder's Snort with some improvements:
 * Integrated geo-ip in reputation preprocessor, so you can block or bypass traffic depending on src/dst geographic location
 * In File Preprocessor: Including further information in ExtraData fields as SHA256, file size, hostname and URI
 * In File Preprocessor: Integrated sending captured files to S3
-
+* In File Preprocessor: Integrated drop by file MIME type.
+* In File Preprocessor: Integrated drop by file size.

--- a/configure
+++ b/configure
@@ -664,6 +664,8 @@ HAVE_TARGET_BASED_FALSE
 HAVE_TARGET_BASED_TRUE
 HAVE_LZMA_FALSE
 HAVE_LZMA_TRUE
+ENABLE_MIME_DROP_FALSE
+ENABLE_MIME_DROP_TRUE
 HAVE_S3FILE_FALSE
 HAVE_S3FILE_TRUE
 HAVE_REPUTATIONGEOIP_FALSE
@@ -839,6 +841,7 @@ with_geoip_libraries
 enable_remote_file_s3
 with_libs3_includes
 with_libs3_libraries
+enable_mime_drop
 enable_extradata_file
 enable_lzma
 with_lzma_includes
@@ -1529,6 +1532,7 @@ Optional Features:
   --disable-dlclose        Only use if you are developing dynamic preprocessors or shared object rules.  Disable (--disable-dlclose) for testing valgrind leaks in dynamic libraries so a usable backtrace is reported.  Enabled by default.
   --enable-reputationgeoip Enable Reputation GeoIP Support (adds GeoIP support implicitly)
   --enable-remote-file-s3  Enable S3 file saving (implies s3 libs)
+  --enable-mime-drop  Enable DROP via MIME type and FILE size
   --enable-extradata-file       Enable ExtraData File collection.
   --disable-lzma           Disable LZMA Decompression
   --disable-gre            Disable GRE and IP in IP encapsulation support
@@ -2696,7 +2700,7 @@ ac_config_headers="$ac_config_headers config.h"
 
 # When changing the snort version, please also update the VERSION
 # definition in "src/win32/WIN32-Includes/config.h"
-am__api_version='1.14'
+am__api_version='1.13'
 
 ac_aux_dir=
 for ac_dir in "$srcdir" "$srcdir/.." "$srcdir/../.."; do
@@ -3263,47 +3267,6 @@ am__tar='$${TAR-tar} chof - "$$tardir"' am__untar='$${TAR-tar} xf -'
 
 
 
-# POSIX will say in a future version that running "rm -f" with no argument
-# is OK; and we want to be able to make that assumption in our Makefile
-# recipes.  So use an aggressive probe to check that the usage we want is
-# actually supported "in the wild" to an acceptable degree.
-# See automake bug#10828.
-# To make any issue more visible, cause the running configure to be aborted
-# by default if the 'rm' program in use doesn't match our expectations; the
-# user can still override this though.
-if rm -f && rm -fr && rm -rf; then : OK; else
-  cat >&2 <<'END'
-Oops!
-
-Your 'rm' program seems unable to run without file operands specified
-on the command line, even when the '-f' option is present.  This is contrary
-to the behaviour of most rm programs out there, and not conforming with
-the upcoming POSIX standard: <http://austingroupbugs.net/view.php?id=542>
-
-Please tell bug-automake@gnu.org about your system, including the value
-of your $PATH and any error possibly output before this message.  This
-can help us improve future automake versions.
-
-END
-  if test x"$ACCEPT_INFERIOR_RM_PROGRAM" = x"yes"; then
-    echo 'Configuration will proceed anyway, since you have set the' >&2
-    echo 'ACCEPT_INFERIOR_RM_PROGRAM variable to "yes"' >&2
-    echo >&2
-  else
-    cat >&2 <<'END'
-Aborting the configuration process, to ensure you take notice of the issue.
-
-You can download and install GNU coreutils to get an 'rm' implementation
-that behaves properly: <http://www.gnu.org/software/coreutils/>.
-
-If you want to complete the configuration process using your problematic
-'rm' anyway, export the environment variable ACCEPT_INFERIOR_RM_PROGRAM
-to "yes", and re-run configure.
-
-END
-    as_fn_error $? "Your 'rm' program is bad, sorry." "$LINENO" 5
-  fi
-fi
 
 NO_OPTIMIZE="no"
 
@@ -4158,65 +4121,6 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC understands -c and -o together" >&5
-$as_echo_n "checking whether $CC understands -c and -o together... " >&6; }
-if ${am_cv_prog_cc_c_o+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-  # Make sure it works both with $CC and with simple cc.
-  # Following AC_PROG_CC_C_O, we do the test twice because some
-  # compilers refuse to overwrite an existing .o file with -o,
-  # though they will create one.
-  am_cv_prog_cc_c_o=yes
-  for am_i in 1 2; do
-    if { echo "$as_me:$LINENO: $CC -c conftest.$ac_ext -o conftest2.$ac_objext" >&5
-   ($CC -c conftest.$ac_ext -o conftest2.$ac_objext) >&5 2>&5
-   ac_status=$?
-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
-   (exit $ac_status); } \
-         && test -f conftest2.$ac_objext; then
-      : OK
-    else
-      am_cv_prog_cc_c_o=no
-      break
-    fi
-  done
-  rm -f core conftest*
-  unset am_i
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_prog_cc_c_o" >&5
-$as_echo "$am_cv_prog_cc_c_o" >&6; }
-if test "$am_cv_prog_cc_c_o" != yes; then
-   # Losing compiler, so override with the script.
-   # FIXME: It is wrong to rewrite CC.
-   # But if we don't then we get into trouble of one sort or another.
-   # A longer-term fix would be to have automake use am__CC in this case,
-   # and then we could set am__CC="\$(top_srcdir)/compile \$(CC)"
-   CC="$am_aux_dir/compile $CC"
-fi
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
 
 depcc="$CC"   am_compiler_list=
 
@@ -5176,65 +5080,6 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC understands -c and -o together" >&5
-$as_echo_n "checking whether $CC understands -c and -o together... " >&6; }
-if ${am_cv_prog_cc_c_o+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-  # Make sure it works both with $CC and with simple cc.
-  # Following AC_PROG_CC_C_O, we do the test twice because some
-  # compilers refuse to overwrite an existing .o file with -o,
-  # though they will create one.
-  am_cv_prog_cc_c_o=yes
-  for am_i in 1 2; do
-    if { echo "$as_me:$LINENO: $CC -c conftest.$ac_ext -o conftest2.$ac_objext" >&5
-   ($CC -c conftest.$ac_ext -o conftest2.$ac_objext) >&5 2>&5
-   ac_status=$?
-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
-   (exit $ac_status); } \
-         && test -f conftest2.$ac_objext; then
-      : OK
-    else
-      am_cv_prog_cc_c_o=no
-      break
-    fi
-  done
-  rm -f core conftest*
-  unset am_i
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_prog_cc_c_o" >&5
-$as_echo "$am_cv_prog_cc_c_o" >&6; }
-if test "$am_cv_prog_cc_c_o" != yes; then
-   # Losing compiler, so override with the script.
-   # FIXME: It is wrong to rewrite CC.
-   # But if we don't then we get into trouble of one sort or another.
-   # A longer-term fix would be to have automake use am__CC in this case,
-   # and then we could set am__CC="\$(top_srcdir)/compile \$(CC)"
-   CC="$am_aux_dir/compile $CC"
-fi
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
 
 depcc="$CC"   am_compiler_list=
 
@@ -7774,7 +7619,7 @@ ia64-*-hpux*)
   rm -rf conftest*
   ;;
 
-x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
+x86_64-*kfreebsd*-gnu|x86_64-*linux*|ppc*-*linux*|powerpc*-*linux*| \
 s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
   # Find out which ABI we are using.
   echo 'int i;' > conftest.$ac_ext
@@ -7792,10 +7637,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	  x86_64-*linux*)
 	    LD="${LD-ld} -m elf_i386"
 	    ;;
-	  powerpc64le-*linux*)
-	    LD="${LD-ld} -m elf32lppclinux"
-	    ;;
-	  powerpc64-*linux*)
+	  ppc64-*linux*|powerpc64-*linux*)
 	    LD="${LD-ld} -m elf32ppclinux"
 	    ;;
 	  s390x-*linux*)
@@ -7814,10 +7656,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
 	  x86_64-*linux*)
 	    LD="${LD-ld} -m elf_x86_64"
 	    ;;
-	  powerpcle-*linux*)
-	    LD="${LD-ld} -m elf64lppc"
-	    ;;
-	  powerpc-*linux*)
+	  ppc*-*linux*|powerpc*-*linux*)
 	    LD="${LD-ld} -m elf64ppc"
 	    ;;
 	  s390*-*linux*|s390*-*tpf*)
@@ -11963,10 +11802,14 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
+  # Add ABI-specific directories to the system library path.
+  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+
   # Append ld.so.conf contents to the search path
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on
@@ -16557,6 +16400,27 @@ fi
     fi
 fi
 
+# Check whether --enable-mime-drop was given.
+if test "${enable_mime_drop+set}" = set; then :
+  enableval=$enable_mime_drop; enable_mime_drop="$enableval"
+else
+  enable_mime_drop="no"
+fi
+
+
+ if test "x$enable_mime_drop" = "yex"; then
+  ENABLE_MIME_DROP_TRUE=
+  ENABLE_MIME_DROP_FALSE='#'
+else
+  ENABLE_MIME_DROP_TRUE='#'
+  ENABLE_MIME_DROP_FALSE=
+fi
+
+
+if test "x$enable_mime_drop" = "xyes"; then
+  CPPFLAGS="${CPPFLAGS} -DHAVE_MIME_DROP"
+fi
+
 # Check whether --enable-extradata-file was given.
 if test "${enable_extradata_file+set}" = set; then :
   enableval=$enable_extradata_file; enable_extradata_file="$enableval"
@@ -17218,6 +17082,7 @@ $as_echo "#define FEAT_OPEN_APPID 1" >>confdefs.h
 
 
 
+
 if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
 	if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
@@ -17346,6 +17211,7 @@ if test -n "$luajit_CFLAGS"; then
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_luajit_CFLAGS=`$PKG_CONFIG --cflags "luajit" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
 fi
@@ -17362,6 +17228,7 @@ if test -n "$luajit_LIBS"; then
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_luajit_LIBS=`$PKG_CONFIG --libs "luajit" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
 fi
@@ -17381,9 +17248,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        luajit_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors "luajit" 2>&1`
+	        luajit_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "luajit" 2>&1`
         else
-	        luajit_PKG_ERRORS=`$PKG_CONFIG --print-errors "luajit" 2>&1`
+	        luajit_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "luajit" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$luajit_PKG_ERRORS" >&5
@@ -17766,6 +17633,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_S3FILE_TRUE}" && test -z "${HAVE_S3FILE_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_S3FILE\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${ENABLE_MIME_DROP_TRUE}" && test -z "${ENABLE_MIME_DROP_FALSE}"; then
+  as_fn_error $? "conditional \"ENABLE_MIME_DROP\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_LZMA_TRUE}" && test -z "${HAVE_LZMA_FALSE}"; then
@@ -18275,7 +18146,7 @@ config.status
 configured by $0, generated by GNU Autoconf 2.69,
   with options \\"\$ac_cs_config\\"
 
-Copyright (C)  Free Software Foundation, Inc.
+Copyright (C) 2012 Free Software Foundation, Inc.
 This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 

--- a/configure.in
+++ b/configure.in
@@ -1004,6 +1004,16 @@ if test "x$enable_file_s3" = "xyes"; then
     fi
 fi
 
+AC_ARG_ENABLE(mime-drop,
+[  --enable-mime-drop  Enable DROP via MIME type and FILE size],
+       enable_mime_drop="$enableval", enable_mime_drop="no")
+
+AM_CONDITIONAL(ENABLE_MIME_DROP, test "x$enable_mime_drop" = "yex")
+
+if test "x$enable_mime_drop" = "xyes"; then
+  CPPFLAGS="${CPPFLAGS} -DHAVE_MIME_DROP"
+fi
+
 AC_ARG_ENABLE(extradata-file,
 [  --enable-extradata-file       Enable ExtraData File collection.],
        enable_extradata_file="$enableval", enable_extradata_file="no")

--- a/src/dynamic-preprocessors/file/file_inspect_config.h
+++ b/src/dynamic-preprocessors/file/file_inspect_config.h
@@ -61,10 +61,10 @@ typedef struct _fileInspectConfig
     bool file_type_enabled;
     bool file_signature_enabled;
     bool file_capture_enabled;
+    uint32_t file_capture_queue_size;
 #ifdef HAVE_EXTRADATA_FILE
     bool file_extradata_enabled;
 #endif
-    uint32_t file_capture_queue_size;
     char *capture_dir;
     int ref_count;
     char *hostname;
@@ -84,13 +84,20 @@ typedef struct _fileInspectConfig
 #if defined(DEBUG_MSGS) || defined (REG_TEST)
     int verdict_delay; /* used for debug, mimic delay to get verdicts */
 #endif
-#if HAVE_S3FILE
+#ifdef HAVE_S3FILE
     struct s3_info {
         char *bucket;
         char *cluster;
         char *access_key;
         char *secret_key;
     } s3;
+#endif
+#ifdef HAVE_MIME_DROP
+    struct mime_info {
+        bool file_capture_enable_drop;
+        uint32_t file_capture_max_file_size;
+        char *file_capture_mime_blacklist;
+    } mime;
 #endif
     uint32_t capture_disk_size;  /* In megabytes*/
 


### PR DESCRIPTION
[PR] Fix `File_Verdict file_agent_type_callback` and Add Enhanced Features to file preprocessor

Summary:
This pull request addresses a bug in the `File_Verdict` module's `file_agent_type_callback` function, which was incorrectly returning "UNKNOW" file type when signature or capture was enabled. Additionally, it integrates new features to enhance file handling in inline mode, including dropping files based on their type and maximum size. Furthermore, dynamic compilation is now supported by `./configure --enable-mime-drop` option.

Changes Made:
- Fixed a bug in the `File_Verdict` module's `file_agent_type_callback` function to correctly determine file types when signature or capture is enabled.
- Integrated the ability to drop files based on their type in inline mode.
- Integrated the ability to drop files based on their maximum size in inline mode.
- Added support for dynamic compilation with the `--enable-mime-drop` option.

Example Configuration of the File Preprocessor:
```plaintext
preprocessor file_inspect:
  - type_id
  - capture_queue_size: 5000
  - signature
  - track_extradata
  - enable_drop_on_byte_match
  - max_file_size: 0
  - file_capture_mime_blacklist: [21]
  - s3_bucket: malware
  - s3_cluster: s3.redborder.cluster
  - seenlist: files/seen.list
  - blacklist: files/black.list
  - sha_cache_max_size_m: 1024
  - sha_cache_min_rows: 65536
  - s3_access_key: your_key
  - s3_secret_key: your_secret_key
  ```
**Additional Information**

The `enable_drop_on_byte_match` option enables the module to drop files based on byte matching rules (magic and capture files). The integer values in the `file_capture_mime_blacklist` represent the rule SIDs (used to uniquely identify Snort rules) of the preprocessor rules.

For example, in the `file_capture.rules` file:

```plaintext
alert (msg:"PDF file"; sid:289; gid:146; rev:1; metadata:rule-type preproc;)
  ```

And in the `file_magic.conf` file:

```plaintext
file type:PDF; id:289; category:PDF files; msg:'PDF file'; rev:1; content:| 25 50 44 46 2D 31 2E 37 |; offset:0;
  ```

To drop the PDF files with SID 289, you can specify file_capture_mime_blacklist [289].

**Note**

For the `max_file_size` option to work, you need to have corresponding rules defined in the file_magic.conf file and the file_capture.rules file. If these rules are not present, the preprocessor will not trigger accordingly.

The separator for the SID blacklist is `|` by default

For example:

```plaintext
preprocessor file_inspect:
  - type_id
  - capture_queue_size: 5000
  - signature
  - track_extradata
  - enable_drop_on_byte_match
  - max_file_size: 0
  - file_capture_mime_blacklist: [21|289]
  - s3_bucket: malware
  - s3_cluster: s3.redborder.cluster
  - seenlist: files/seen.list
  - blacklist: files/black.list
  - sha_cache_max_size_m: 1024
  - sha_cache_min_rows: 65536
  - s3_access_key: your_key
  - s3_secret_key: your_secret_key
  ```
